### PR TITLE
Final update for 2.52

### DIFF
--- a/RAS_Script_ChangeLog.txt
+++ b/RAS_Script_ChangeLog.txt
@@ -13,6 +13,39 @@
 #Version 1.0 released to the community on 5-August-2020
 #
 
+#Version 2.52 7-Feb-2022
+#	Added Function GetRASStatus to return the full status text for several RAS Status cmdlets
+#		Updated all AgentState outputs to use the value from GetRASStatus
+#	Added HALB output
+#		Virtual Servers
+#			Properties
+#			General
+#			LB gateway payload
+#			LB SSL payload
+#			Devices
+#			Advanced
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed call to Get-RASThemeFooterURL to always return an array (Thanks to Thomas Krampe for the debugging time)
+#	Fixed missing RDS Group Default settings (Thanks to Thomas Krampe)
+#	Fixed several logic errors where I assumed there were always RDS groups
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	For Policy setting Session/Connection/Primary connection/Login/Auto Login, change property name AutoStart to AutoLogin
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Function OutputFarmSite, only get the first Publishing Agent server for the Farm/Site settings
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+#	Updated to allow running the script for RAS versions greater than 18.1
+
 #Version 2.51 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables
 #	Added Function OutputReportFooter


### PR DESCRIPTION
#Version 2.52 7-Feb-2022
#	Added Function GetRASStatus to return the full status text for several RAS Status cmdlets
#		Updated all AgentState outputs to use the value from GetRASStatus
#	Added HALB output
#		Virtual Servers
#			Properties
#			General
#			LB gateway payload
#			LB SSL payload
#			Devices
#			Advanced
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed call to Get-RASThemeFooterURL to always return an array (Thanks to Thomas Krampe for the debugging time)
#	Fixed missing RDS Group Default settings (Thanks to Thomas Krampe)
#	Fixed several logic errors where I assumed there were always RDS groups
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	For Policy setting Session/Connection/Primary connection/Login/Auto Login, change property name AutoStart to AutoLogin
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Function OutputFarmSite, only get the first Publishing Agent server for the Farm/Site settings
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file
#	Updated to allow running the script for RAS versions greater than 18.1